### PR TITLE
fix(dnsmasq): restart dnsmasq when openvpn restarts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ openvpn_email_signature: |
 openvpn_manage_nginx_vhost: "true"
 openvpn_manage_dehydrated: "true"
 
+openvpn_dnsmasq_config: ""
+
 ca_settings:
   - key: "set_var EASYRSA_REQ_COUNTRY"
     value: "CZ"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,8 @@
   service:
     name: "openvpn-server@{{ openvpn_name }}"
     state: restarted
+  notify: restart dnsmasq
+- name: restart dnsmasq
+  service:
+    name: dnsmasq
+    state: restarted

--- a/tasks/clients.yml
+++ b/tasks/clients.yml
@@ -49,7 +49,7 @@
   with_items: "{{ openvpn_clients[openvpn_name] }}"
 
 - name: Create google-authenticator config file for OpenVPN
-  shell: "/usr/bin/yes y | /usr/bin/google-authenticator -t -d -r3 -R30 -f -l \"OpenVPN Server\" -s {{ openvpn_authenticator_path }}/{{ item.name}}"
+  shell: "/usr/bin/yes y | /usr/bin/google-authenticator -C -t -d -r3 -R30 -f -l \"OpenVPN Server\" -s {{ openvpn_authenticator_path }}/{{ item.name}}"
   args:
     creates: "{{ openvpn_authenticator_path }}/{{ item.name }}"
   with_items: "{{ openvpn_clients[openvpn_name] }}"

--- a/tasks/clients.yml
+++ b/tasks/clients.yml
@@ -21,6 +21,15 @@
     EASYRSA_REQ_CN: "{{ item.name }}"
   with_items: "{{ openvpn_clients[openvpn_name] }}"
 
+- name: Revoke client certificate
+  command: "./easyrsa --batch revoke {{ item.name }}"
+  args:
+    chdir: "/etc/openvpn/server/{{ openvpn_name }}/easy-rsa/"
+    creates: "/etc/openvpn/server/{{ openvpn_name }}/easy-rsa/pki/issued/{{ item.name }}.revoked"
+  environment:
+    EASYRSA_REQ_CN: "{{ item.name }}"
+  with_items: "{{ openvpn_clients[openvpn_name] | selectattr('state', 'equalto', 'absent')}}"
+
 - name: Create client config files directory
   file:
     path: "/etc/openvpn/server/{{ openvpn_name }}/easy-rsa/configs/"
@@ -43,6 +52,15 @@
   shell: "/usr/bin/yes y | /usr/bin/google-authenticator -t -d -r3 -R30 -f -l \"OpenVPN Server\" -s {{ openvpn_authenticator_path }}/{{ item.name}}"
   args:
     creates: "{{ openvpn_authenticator_path }}/{{ item.name }}"
+  with_items: "{{ openvpn_clients[openvpn_name] }}"
+  tags:
+    - authenticator
+  when: openvpn_authenticator == true
+
+- name: Delete google-authenticator config file for absent users
+  file:
+    path: "{{ openvpn_authenticator_path }}/{{ item.name }}"
+    state: "{{ client.state | default('present') }}"
   with_items: "{{ openvpn_clients[openvpn_name] }}"
   tags:
     - authenticator
@@ -73,6 +91,7 @@
     name: "{{ item.name }}"
     create_home: false
     shell: /usr/sbin/nologin
+    state: "{{ client.state | default('present') }}"
   when: openvpn_authenticator == true
   with_items: "{{ openvpn_clients[openvpn_name] }}"
 

--- a/tasks/clients.yml
+++ b/tasks/clients.yml
@@ -60,7 +60,7 @@
 - name: Delete google-authenticator config file for absent users
   file:
     path: "{{ openvpn_authenticator_path }}/{{ item.name }}"
-    state: "{{ client.state | default('present') }}"
+    state: "{{ client.state | default('file') }}"
   with_items: "{{ openvpn_clients[openvpn_name] }}"
   tags:
     - authenticator

--- a/tasks/clients.yml
+++ b/tasks/clients.yml
@@ -21,14 +21,14 @@
     EASYRSA_REQ_CN: "{{ item.name }}"
   with_items: "{{ openvpn_clients[openvpn_name] }}"
 
-- name: Revoke client certificate
-  command: "./easyrsa --batch revoke {{ item.name }}"
-  args:
-    chdir: "/etc/openvpn/server/{{ openvpn_name }}/easy-rsa/"
-    creates: "/etc/openvpn/server/{{ openvpn_name }}/easy-rsa/pki/issued/{{ item.name }}.revoked"
-  environment:
-    EASYRSA_REQ_CN: "{{ item.name }}"
-  with_items: "{{ openvpn_clients[openvpn_name] | selectattr('state','defined') | selectattr('state', '==', 'absent') }}"
+#- name: Revoke client certificate
+#  command: "./easyrsa --batch revoke {{ item.name }}"
+#  args:
+#    chdir: "/etc/openvpn/server/{{ openvpn_name }}/easy-rsa/"
+#    creates: "/etc/openvpn/server/{{ openvpn_name }}/easy-rsa/pki/issued/{{ item.name }}.revoked"
+#  environment:
+#    EASYRSA_REQ_CN: "{{ item.name }}"
+#  with_items: "{{ openvpn_clients[openvpn_name] | selectattr('state','defined') | selectattr('state', '==', 'absent') }}"
 
 - name: Create client config files directory
   file:

--- a/tasks/clients.yml
+++ b/tasks/clients.yml
@@ -28,7 +28,7 @@
     creates: "/etc/openvpn/server/{{ openvpn_name }}/easy-rsa/pki/issued/{{ item.name }}.revoked"
   environment:
     EASYRSA_REQ_CN: "{{ item.name }}"
-  with_items: "{{ openvpn_clients[openvpn_name] | selectattr('state', 'equalto', 'absent')}}"
+  with_items: "{{ openvpn_clients[openvpn_name] | selectattr('state','defined') | selectattr('state', '==', 'absent') }}"
 
 - name: Create client config files directory
   file:

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -1,6 +1,4 @@
-- name: Configure dnsmasq for all interfaces
-  lineinfile:
-    path: /etc/dnsmasq.conf
-    regexp: '.*bind-interfaces.*'
-    line: 'listen-address={{ openvpn_internal_address }}'
-
+- name: Configure dnsmasq for vpn interfaces
+  template:
+    src: templates/dnsmasq/dnsmasq.conf
+    dest: /etc/dnsmasq.conf

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -1,6 +1,6 @@
 - name: Configure dnsmasq for all interfaces
   lineinfile:
-    path: /etc/selinux/config
+    path: /etc/dnsmasq.conf
     regexp: '.*bind-interfaces.*'
     line: bind-interfaces
 

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -2,5 +2,5 @@
   lineinfile:
     path: /etc/dnsmasq.conf
     regexp: '.*bind-interfaces.*'
-    line: bind-interfaces
+    line: 'listen-address={{ openvpn_internal_address }}'
 

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -2,3 +2,10 @@
   template:
     src: templates/dnsmasq/dnsmasq.conf
     dest: /etc/dnsmasq.conf
+  notify: restart dnsmasq
+
+- name: Enable and start dnsmasq
+  service:
+    name: dnsmasq
+    enabled: yes
+    state: started

--- a/tasks/iptables-chains.yml
+++ b/tasks/iptables-chains.yml
@@ -6,7 +6,7 @@
 
 - name: Create custom iptables chain
   command: "iptables -N fwd-{{ item }}"
-  when: "'Chain fwd-{{ item }}' not in iptables_rules.stdout"
+  when: "'Chain fwd-' + item not in iptables_rules.stdout"
   with_items: "{{ openvpn_networks }}"
 
 - name: Set forward policy

--- a/tasks/iptables-rules.yml
+++ b/tasks/iptables-rules.yml
@@ -14,6 +14,7 @@
     source: "{{ client.address }}"
     jump: ACCEPT
     comment: "{{ client.name }}"
+    state: "{{ client.state | default('present') }}"
   when: network in client.networks
   loop: "{{ openvpn_clients[openvpn_name] }}"
   loop_control:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,6 @@
 - include: iptables-rules.yml network={{ item }}
   with_items: "{{ openvpn_networks }}"
 - include: nginx.yml
-  when: "{{ openvpn_manage_nginx_vhost }}" == "true"
+  when: openvpn_manage_nginx_vhost == true
 - include: dehydrated.yml
-  when: "{{ openvpn_manage_dehydrated }}" == "true"
+  when: openvpn_manage_dehydrated == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
-- include: init.yml
-- include: server.yml
-- include: dnsmasq.yml
-- include: clients.yml
-- include: iptables-chains.yml
-- include: iptables-rules.yml network={{ item }}
+- include_tasks: init.yml
+- include_tasks: server.yml
+- include_tasks: dnsmasq.yml
+- include_tasks: clients.yml
+- include_tasks: iptables-chains.yml
+- include_tasks: iptables-rules.yml network={{ item }}
   with_items: "{{ openvpn_networks }}"
-- include: nginx.yml
+- include_tasks: nginx.yml
   when: openvpn_manage_nginx_vhost == true
-- include: dehydrated.yml
+- include_tasks: dehydrated.yml
   when: openvpn_manage_dehydrated == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,9 @@
 - include_tasks: dnsmasq.yml
 - include_tasks: clients.yml
 - include_tasks: iptables-chains.yml
-- include_tasks: iptables-rules.yml network={{ item }}
+- include_tasks: iptables-rules.yml
+  vars:
+    network: "{{ item }}"
   with_items: "{{ openvpn_networks }}"
 - include_tasks: nginx.yml
   when: openvpn_manage_nginx_vhost == true

--- a/templates/dnsmasq/dnsmasq.conf
+++ b/templates/dnsmasq/dnsmasq.conf
@@ -1,0 +1,4 @@
+interface=tun0
+bind-interfaces
+
+{{ openvpn_dnsmasq_config }}

--- a/templates/easy-rsa/sendconfig.j2
+++ b/templates/easy-rsa/sendconfig.j2
@@ -17,7 +17,7 @@ Dear ${USER},
 
 please see attached configuration file: {{ openvpn_hostname }}.ovpn. Just import this file into your favourite OpenVPN client:
 
-* macOS - tunnelblick or viscosity
+* macOS - https://openvpn.net/client/ - OpenVPN client
 * windows - OpenVPN GUI
 * linux - openvpn / network manager
 


### PR DESCRIPTION
## Summary
- Restart dnsmasq automatically when OpenVPN restarts (handler chain)
- Ensure dnsmasq service is enabled and started
- Notify restart on config change

## Problem
When OpenVPN restarts, `tun0` is recreated. dnsmasq uses `bind-interfaces` and binds to `tun0` at startup, so after OpenVPN restart it stops responding on the new interface. VPN clients get DNS pushed to `172.31.240.1` but dnsmasq doesn't respond → all DNS resolution fails → no traffic works (including non-VPN traffic).

## Test plan
- [ ] Run the playbook with OpenVPN config change that triggers restart
- [ ] Verify dnsmasq is restarted after OpenVPN restart
- [ ] Verify `dig @172.31.240.1 google.com` works after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)